### PR TITLE
Make the locale to be consistent across containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
+
+# Set the locale
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
 ARG FITS_VERSION=0.8.4-1~14.04
 ARG FITS_USER=fits
 ARG FITS_UID=333


### PR DESCRIPTION
The various docker container components of Archivematica utilise locale
inconistently. This fix updates the FITS container to be consistent with
en_US.UTF-8 along with the other containers we are using. Submitted in
support of GitHub issue: https://github.com/artefactual/archivematica/issues/898

Branch created and tested successfully with a single AM workflow containing doc files and pdf for characterisation,

```
b01385975d11        artefactual/fits-ngserver:dev_issue-898-update-container-encoding   "/usr/bin/fits-ngser…"   12 minutes ago      Up 12 minutes       0.0.0.0:62005->2113/tcp                          compose_fits_1
```
```
ross-spencer@artefactual:~/git/artefactual-labs/am/compose:$ sudo docker exec -it b01385975d11 bash
fits@b01385975d11:/$ locale
LANG=en_US.UTF-8
LANGUAGE=en_US:en
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=en_US.UTF-8
```

This is an automated build so once reviewed and merged, the image with updated locale information will be available to all users of this container. 